### PR TITLE
feat: USRP B200mini support

### DIFF
--- a/src/spectre_core/capture_configs/_pnames.py
+++ b/src/spectre_core/capture_configs/_pnames.py
@@ -47,4 +47,4 @@ class PName(Enum):
     OBS_LAT              = "obs_lat"
     OBS_LON              = "obs_lon"
     OBS_ALT              = "obs_alt"
-    NORMALISED_GAIN      = "gain"
+    NORMALISED_GAIN      = "normalised_gain"

--- a/src/spectre_core/capture_configs/_pnames.py
+++ b/src/spectre_core/capture_configs/_pnames.py
@@ -47,3 +47,4 @@ class PName(Enum):
     OBS_LAT              = "obs_lat"
     OBS_LON              = "obs_lon"
     OBS_ALT              = "obs_alt"
+    NORMALISED_GAIN      = "gain"

--- a/src/spectre_core/capture_configs/_ptemplates.py
+++ b/src/spectre_core/capture_configs/_ptemplates.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from copy import deepcopy
 
 from ._pnames import PName
-from ._pconstraints import BasePConstraint, EnforceSign, PowerOfTwo
+from ._pconstraints import BasePConstraint, EnforceSign, PowerOfTwo, Bound
 from ._parameters import Parameter
     
 # value type
@@ -299,6 +299,14 @@ _base_ptemplates: dict[PName, PTemplate] = {
                                                 """,
                                             pconstraints=[
                                                 EnforceSign.non_positive
+                                                ]),
+    PName.NORMALISED_GAIN:                  PTemplate(PName.NORMALISED_GAIN,
+                                            str,
+                                            help = """
+                                                 The normalised gain value, where 1.0 is mapped to the max gain of the receiver being used.
+                                                 """,
+                                            pconstraints=[
+                                                Bound(0.0, 1.0)
                                                 ]),
     PName.EVENT_HANDLER_KEY:      PTemplate(PName.EVENT_HANDLER_KEY,      
                                             str,

--- a/src/spectre_core/capture_configs/_ptemplates.py
+++ b/src/spectre_core/capture_configs/_ptemplates.py
@@ -301,7 +301,7 @@ _base_ptemplates: dict[PName, PTemplate] = {
                                                 EnforceSign.non_positive
                                                 ]),
     PName.NORMALISED_GAIN:                  PTemplate(PName.NORMALISED_GAIN,
-                                            str,
+                                            float,
                                             help = """
                                                  The normalised gain value, where 1.0 is mapped to the max gain of the receiver being used.
                                                  """,

--- a/src/spectre_core/receivers/__init__.py
+++ b/src/spectre_core/receivers/__init__.py
@@ -8,7 +8,7 @@ from .plugins._receiver_names import ReceiverName
 from .plugins._test import Test
 from .plugins._rsp1a import RSP1A
 from .plugins._rspduo import RSPduo
-from .plugins._b200_mini import B200Mini
+from .plugins._b200mini import B200mini
 
 from ._base import BaseReceiver
 from ._factory import get_receiver
@@ -16,6 +16,6 @@ from ._register import get_registered_receivers
 from ._spec_names import SpecName
 
 __all__ = [
-    "Test", "RSP1A", "RSPduo", "B200Mini",  "BaseReceiver", "get_receiver", 
+    "Test", "RSP1A", "RSPduo", "B200mini",  "BaseReceiver", "get_receiver", 
     "get_registered_receivers", "SpecName", "ReceiverName"
 ]

--- a/src/spectre_core/receivers/__init__.py
+++ b/src/spectre_core/receivers/__init__.py
@@ -8,6 +8,7 @@ from .plugins._receiver_names import ReceiverName
 from .plugins._test import Test
 from .plugins._rsp1a import RSP1A
 from .plugins._rspduo import RSPduo
+from .plugins._b200_mini import B200Mini
 
 from ._base import BaseReceiver
 from ._factory import get_receiver
@@ -15,6 +16,6 @@ from ._register import get_registered_receivers
 from ._spec_names import SpecName
 
 __all__ = [
-    "Test", "RSP1A", "RSPduo", "BaseReceiver", "get_receiver", 
+    "Test", "RSP1A", "RSPduo", "B200Mini",  "BaseReceiver", "get_receiver", 
     "get_registered_receivers", "SpecName", "ReceiverName"
 ]

--- a/src/spectre_core/receivers/_base.py
+++ b/src/spectre_core/receivers/_base.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Literal, overload
+from typing import Callable, Optional, Literal, overload, Any
 
 from spectre_core.exceptions import ModeNotFoundError
 from spectre_core.capture_configs import (
@@ -236,34 +236,11 @@ class BaseReceiver(ABC):
         """
         self.specs[name] = value
 
-
-    # tell static type checkers the type of specification
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.API_RETUNING_LATENCY]) -> float: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.FREQUENCY_LOWER_BOUND]) -> float: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.FREQUENCY_UPPER_BOUND]) -> float: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.SAMPLE_RATE_LOWER_BOUND]) -> int: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.SAMPLE_RATE_UPPER_BOUND]) -> int: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.BANDWIDTH_LOWER_BOUND]) -> float: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.BANDWIDTH_UPPER_BOUND]) -> float: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.RF_GAIN_UPPER_BOUND]) -> int: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.IF_GAIN_UPPER_BOUND]) -> int: ...
-    @overload
-    def get_spec(self, spec_name: Literal[SpecName.BANDWIDTH_OPTIONS]) -> list[float]: ...
-    
     
     def get_spec(
         self, 
         spec_name: SpecName
-    ) -> float|int|list[float|int]:
+    ) -> Any:
         """
         Retrieve a hardware specification.
 

--- a/src/spectre_core/receivers/_factory.py
+++ b/src/spectre_core/receivers/_factory.py
@@ -11,7 +11,7 @@ from .plugins._receiver_names import ReceiverName
 from .plugins._rsp1a import RSP1A
 from .plugins._rspduo import RSPduo
 from .plugins._test import Test
-from .plugins._b200_mini import B200Mini
+from .plugins._b200mini import B200mini
 
 
 @overload
@@ -40,9 +40,9 @@ def get_receiver(
 
 @overload
 def get_receiver(
-    receiver_name: Literal[ReceiverName.B200_MINI],
+    receiver_name: Literal[ReceiverName.B200MINI],
     mode: Optional[str] = None
-) -> B200Mini:
+) -> B200mini:
     ...
 
 

--- a/src/spectre_core/receivers/_factory.py
+++ b/src/spectre_core/receivers/_factory.py
@@ -11,6 +11,7 @@ from .plugins._receiver_names import ReceiverName
 from .plugins._rsp1a import RSP1A
 from .plugins._rspduo import RSPduo
 from .plugins._test import Test
+from .plugins._b200_mini import B200Mini
 
 
 @overload
@@ -34,6 +35,14 @@ def get_receiver(
     receiver_name: Literal[ReceiverName.TEST],
     mode: Optional[str] = None
 ) -> Test:
+    ...
+
+
+@overload
+def get_receiver(
+    receiver_name: Literal[ReceiverName.B200_MINI],
+    mode: Optional[str] = None
+) -> B200Mini:
     ...
 
 

--- a/src/spectre_core/receivers/_spec_names.py
+++ b/src/spectre_core/receivers/_spec_names.py
@@ -18,6 +18,8 @@ class SpecName(Enum):
     Negative values indicate attenuation.
     :ivar RF_GAIN_UPPER_BOUND: The upper bound for the radio frequency gain, in dB. 
     Negative values indicate attenuation.
+    :ivar API_RETUNING_LATENCY: An empirical estimate of the delay between issuing a command
+    for a receiver to retune its center frequency and the actual physical update of the center frequency. 
     """
     FREQUENCY_LOWER_BOUND    = "frequency_lower_bound"
     FREQUENCY_UPPER_BOUND    = "frequency_upper_bound"

--- a/src/spectre_core/receivers/plugins/_b200_mini.py
+++ b/src/spectre_core/receivers/plugins/_b200_mini.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2024 Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from dataclasses import dataclass
+
+from ._receiver_names import ReceiverName
+from ._usrp import (
+        get_pvalidator_fixed_center_frequency,
+        get_capture_template_fixed_center_frequency
+)
+from .gr._usrp import CaptureMethod
+from .._spec_names import SpecName
+from .._base import BaseReceiver
+from .._register import register_receiver 
+
+@dataclass(frozen=True)
+class Mode:
+    """An operating mode for the `b200-mini` receiver."""
+    FIXED_CENTER_FREQUENCY = "fixed_center_frequency"
+
+
+@register_receiver(ReceiverName.B200_MINI)
+class B200Mini(BaseReceiver):
+    """Receiver implementation for the USRP B200 Mini (https://www.ettus.com/all-products/usrp-b200mini/)"""
+    def _add_specs(
+        self
+    ) -> None:
+        self.add_spec( SpecName.SAMPLE_RATE_LOWER_BOUND, 200e3 )
+        self.add_spec( SpecName.SAMPLE_RATE_UPPER_BOUND, 56e6  )
+        self.add_spec( SpecName.FREQUENCY_LOWER_BOUND  , 70e6  )
+        self.add_spec( SpecName.FREQUENCY_UPPER_BOUND  , 6e9   )
+        self.add_spec( SpecName.BANDWIDTH_LOWER_BOUND  , 200e3 ) 
+        self.add_spec( SpecName.BANDWIDTH_UPPER_BOUND  , 56e6  )
+
+   
+    def _add_capture_methods(
+        self
+    ) -> None:
+       self.add_capture_method(Mode.FIXED_CENTER_FREQUENCY,
+                               CaptureMethod.fixed_center_frequency)
+
+    
+    def _add_pvalidator(
+        self
+    ) -> None:
+        self.add_pvalidator(Mode.FIXED_CENTER_FREQUENCY,
+                            get_pvalidator_fixed_center_frequency(self))
+
+    
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/spectre_core/receivers/plugins/_b200mini.py
+++ b/src/spectre_core/receivers/plugins/_b200mini.py
@@ -40,8 +40,16 @@ class B200mini(BaseReceiver):
        self.add_capture_method(Mode.FIXED_CENTER_FREQUENCY,
                                CaptureMethod.fixed_center_frequency)
 
-    
-    def _add_pvalidator(
+   
+    def _add_capture_templates(
+        self
+    ) -> None:
+        self.add_capture_template(Mode.FIXED_CENTER_FREQUENCY,
+                                  get_capture_template_fixed_center_frequency(self)
+                                 )
+
+
+    def _add_pvalidators(
         self
     ) -> None:
         self.add_pvalidator(Mode.FIXED_CENTER_FREQUENCY,

--- a/src/spectre_core/receivers/plugins/_b200mini.py
+++ b/src/spectre_core/receivers/plugins/_b200mini.py
@@ -16,13 +16,13 @@ from .._register import register_receiver
 
 @dataclass(frozen=True)
 class Mode:
-    """An operating mode for the `b200-mini` receiver."""
+    """An operating mode for the `B200mini` receiver."""
     FIXED_CENTER_FREQUENCY = "fixed_center_frequency"
 
 
 @register_receiver(ReceiverName.B200MINI)
 class B200mini(BaseReceiver):
-    """Receiver implementation for the USRP B200 Mini (https://www.ettus.com/all-products/usrp-b200mini/)"""
+    """Receiver implementation for the USRP B200mini (https://www.ettus.com/all-products/usrp-b200mini/)"""
     def _add_specs(
         self
     ) -> None:
@@ -45,8 +45,7 @@ class B200mini(BaseReceiver):
         self
     ) -> None:
         self.add_capture_template(Mode.FIXED_CENTER_FREQUENCY,
-                                  get_capture_template_fixed_center_frequency(self)
-                                 )
+                                  get_capture_template_fixed_center_frequency(self))
 
 
     def _add_pvalidators(

--- a/src/spectre_core/receivers/plugins/_b200mini.py
+++ b/src/spectre_core/receivers/plugins/_b200mini.py
@@ -20,8 +20,8 @@ class Mode:
     FIXED_CENTER_FREQUENCY = "fixed_center_frequency"
 
 
-@register_receiver(ReceiverName.B200_MINI)
-class B200Mini(BaseReceiver):
+@register_receiver(ReceiverName.B200MINI)
+class B200mini(BaseReceiver):
     """Receiver implementation for the USRP B200 Mini (https://www.ettus.com/all-products/usrp-b200mini/)"""
     def _add_specs(
         self

--- a/src/spectre_core/receivers/plugins/_receiver_names.py
+++ b/src/spectre_core/receivers/plugins/_receiver_names.py
@@ -14,4 +14,4 @@ class ReceiverName(Enum):
     RSP1A     = "rsp1a"
     RSPDUO    = "rspduo"
     TEST      = "test"
-    B200_MINI = "b200_mini"
+    B200MINI =  "b200mini"

--- a/src/spectre_core/receivers/plugins/_receiver_names.py
+++ b/src/spectre_core/receivers/plugins/_receiver_names.py
@@ -10,6 +10,7 @@ class ReceiverName(Enum):
     :ivar RSP1A: SDRPlay RSP1A
     :ivar RSPDUO: SDRPlay RSPduo
     :ivar TEST: `spectre` test receiver.
+    :ivar B200MINI: USRP B200mini.
     """
     RSP1A     = "rsp1a"
     RSPDUO    = "rspduo"

--- a/src/spectre_core/receivers/plugins/_receiver_names.py
+++ b/src/spectre_core/receivers/plugins/_receiver_names.py
@@ -11,6 +11,7 @@ class ReceiverName(Enum):
     :ivar RSPDUO: SDRPlay RSPduo
     :ivar TEST: `spectre` test receiver.
     """
-    RSP1A  = "rsp1a"
-    RSPDUO = "rspduo"
-    TEST   = "test"
+    RSP1A     = "rsp1a"
+    RSPDUO    = "rspduo"
+    TEST      = "test"
+    B200_MINI = "b200_mini"

--- a/src/spectre_core/receivers/plugins/_rsp1a.py
+++ b/src/spectre_core/receivers/plugins/_rsp1a.py
@@ -6,12 +6,12 @@ from dataclasses import dataclass
 
 from ._receiver_names import ReceiverName
 from .gr._rsp1a import CaptureMethod
-from .._spec_names import SpecName
-from .._base import BaseReceiver
 from ._sdrplay_receiver import (
     get_pvalidator_fixed_center_frequency, get_pvalidator_swept_center_frequency,
     get_capture_template_fixed_center_frequency, get_capture_template_swept_center_frequency
 )
+from .._spec_names import SpecName
+from .._base import BaseReceiver
 from .._register import register_receiver
 
 @dataclass(frozen=True)
@@ -24,7 +24,9 @@ class Mode:
 @register_receiver(ReceiverName.RSP1A)
 class RSP1A(BaseReceiver):
     """Receiver implementation for the SDRPlay RSP1A (https://www.sdrplay.com/rsp1a/)"""
-    def _add_specs(self) -> None:
+    def _add_specs(
+            self
+    ) -> None:
         self.add_spec( SpecName.SAMPLE_RATE_LOWER_BOUND, 200e3     )
         self.add_spec( SpecName.SAMPLE_RATE_UPPER_BOUND, 10e6      )
         self.add_spec( SpecName.FREQUENCY_LOWER_BOUND  , 1e3       )

--- a/src/spectre_core/receivers/plugins/_rsp1a.py
+++ b/src/spectre_core/receivers/plugins/_rsp1a.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from ._receiver_names import ReceiverName
 from .gr._rsp1a import CaptureMethod
 from .._spec_names import SpecName
-from ._sdrplay_receiver import SDRPlayReceiver
+from .._base import BaseReceiver
+from ._sdrplay_receiver import (
+    get_pvalidator_fixed_center_frequency, get_pvalidator_swept_center_frequency,
+    get_capture_template_fixed_center_frequency, get_capture_template_swept_center_frequency
+)
 from .._register import register_receiver
 
 @dataclass(frozen=True)
@@ -18,7 +22,7 @@ class Mode:
 
 
 @register_receiver(ReceiverName.RSP1A)
-class RSP1A(SDRPlayReceiver):
+class RSP1A(BaseReceiver):
     """Receiver implementation for the SDRPlay RSP1A (https://www.sdrplay.com/rsp1a/)"""
     def _add_specs(self) -> None:
         self.add_spec( SpecName.SAMPLE_RATE_LOWER_BOUND, 200e3     )
@@ -45,15 +49,15 @@ class RSP1A(SDRPlayReceiver):
         self
     ) -> None:
         self.add_capture_template(Mode.FIXED_CENTER_FREQUENCY,
-                                  self._get_capture_template_fixed_center_frequency())
+                                  get_capture_template_fixed_center_frequency(self))
         self.add_capture_template(Mode.SWEPT_CENTER_FREQUENCY,
-                                  self._get_capture_template_swept_center_frequency())
+                                  get_capture_template_swept_center_frequency(self))
         
     
     def _add_pvalidators(
         self
     ) -> None:
         self.add_pvalidator(Mode.FIXED_CENTER_FREQUENCY,
-                            self._get_pvalidator_fixed_center_frequency())
+                            get_pvalidator_fixed_center_frequency(self))
         self.add_pvalidator(Mode.SWEPT_CENTER_FREQUENCY,
-                            self._get_pvalidator_swept_center_frequency())
+                            get_pvalidator_swept_center_frequency(self))

--- a/src/spectre_core/receivers/plugins/_rspduo.py
+++ b/src/spectre_core/receivers/plugins/_rspduo.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from ._receiver_names import ReceiverName
 from .gr._rspduo import CaptureMethod
 from .._spec_names import SpecName
-from ._sdrplay_receiver import SDRPlayReceiver
+from ._sdrplay_receiver import (
+    get_pvalidator_fixed_center_frequency, get_pvalidator_swept_center_frequency,
+    get_capture_template_fixed_center_frequency, get_capture_template_swept_center_frequency
+)
+from .._base import BaseReceiver
 from .._register import register_receiver
 
 
@@ -20,7 +24,7 @@ class Mode:
 
 
 @register_receiver(ReceiverName.RSPDUO)
-class RSPduo(SDRPlayReceiver):
+class RSPduo(BaseReceiver):
     """Receiver implementation for the SDRPlay RSPduo (https://www.sdrplay.com/rspduo/)"""
     def _add_specs(self) -> None:
         self.add_spec( SpecName.SAMPLE_RATE_LOWER_BOUND, 200e3     )
@@ -49,19 +53,19 @@ class RSPduo(SDRPlayReceiver):
         self
     ) -> None:
         self.add_capture_template(Mode.TUNER_1_FIXED_CENTER_FREQUENCY,
-                                  self._get_capture_template_fixed_center_frequency())
+                                  get_capture_template_fixed_center_frequency(self))
         self.add_capture_template(Mode.TUNER_2_FIXED_CENTER_FREQUENCY,
-                                  self._get_capture_template_fixed_center_frequency())
+                                  get_capture_template_fixed_center_frequency(self))
         self.add_capture_template(Mode.TUNER_1_SWEPT_CENTER_FREQUENCY,
-                                  self._get_capture_template_swept_center_frequency())
+                                  get_capture_template_swept_center_frequency(self))
         
     
     def _add_pvalidators(
         self
     ) -> None:
         self.add_pvalidator(Mode.TUNER_1_FIXED_CENTER_FREQUENCY,
-                            self._get_pvalidator_fixed_center_frequency())
+                            get_pvalidator_fixed_center_frequency(self))
         self.add_pvalidator(Mode.TUNER_2_FIXED_CENTER_FREQUENCY,
-                            self._get_pvalidator_fixed_center_frequency())
+                            get_pvalidator_fixed_center_frequency(self))
         self.add_pvalidator(Mode.TUNER_1_SWEPT_CENTER_FREQUENCY,
-                            self._get_pvalidator_swept_center_frequency())
+                            get_pvalidator_swept_center_frequency(self))

--- a/src/spectre_core/receivers/plugins/_sdrplay_receiver.py
+++ b/src/spectre_core/receivers/plugins/_sdrplay_receiver.py
@@ -16,7 +16,7 @@ from .._spec_names import SpecName
 def get_pvalidator_fixed_center_frequency(
     sdrplay_receiver: BaseReceiver 
 ) -> Callable[[Parameters], None]:
-    def pvalidator(parameters: Parameters):
+    def pvalidator(parameters: Parameters) -> None:
         validate_fixed_center_frequency(parameters)
     return pvalidator
 
@@ -24,7 +24,7 @@ def get_pvalidator_fixed_center_frequency(
 def get_pvalidator_swept_center_frequency(
     sdrplay_receiver: BaseReceiver 
 ) -> Callable[[Parameters], None]:
-    def pvalidator(parameters: Parameters):
+    def pvalidator(parameters: Parameters) -> None:
         validate_swept_center_frequency(parameters,
                                         sdrplay_receiver.get_spec(SpecName.API_RETUNING_LATENCY))
     return pvalidator

--- a/src/spectre_core/receivers/plugins/_sdrplay_receiver.py
+++ b/src/spectre_core/receivers/plugins/_sdrplay_receiver.py
@@ -12,179 +12,163 @@ from spectre_core.capture_configs import (
 from .._base import BaseReceiver
 from .._spec_names import SpecName
 
-class SDRPlayReceiver(BaseReceiver):
-    """An abstract base class for SDRPlay receivers.
+
+def get_pvalidator_fixed_center_frequency(
+    sdrplay_receiver: BaseReceiver 
+) -> Callable[[Parameters], None]:
+    def pvalidator(parameters: Parameters):
+        validate_fixed_center_frequency(parameters)
+    return pvalidator
+
+
+def get_pvalidator_swept_center_frequency(
+    sdrplay_receiver: BaseReceiver 
+) -> Callable[[Parameters], None]:
+    def pvalidator(parameters: Parameters):
+        validate_swept_center_frequency(parameters,
+                                        sdrplay_receiver.get_spec(SpecName.API_RETUNING_LATENCY))
+    return pvalidator
+
+
+def get_capture_template_fixed_center_frequency(
+    sdrplay_receiver: BaseReceiver
+) -> CaptureTemplate:
     
-    Includes ready-to-go pvalidators and capture templates which are shared by all subclasses. 
-    Each subclasses must define the following hardware specifications:
-    
-    .. code-block:: python
-        def _add_specs(self) -> None:
-            self.add_spec( SpecName.SAMPLE_RATE_LOWER_BOUND, <TBD> )
-            self.add_spec( SpecName.SAMPLE_RATE_UPPER_BOUND, <TBD> )
-            self.add_spec( SpecName.FREQUENCY_LOWER_BOUND  , <TBD> )
-            self.add_spec( SpecName.FREQUENCY_UPPER_BOUND  , <TBD> )
-            self.add_spec( SpecName.IF_GAIN_UPPER_BOUND    , <TBD> )
-            self.add_spec( SpecName.RF_GAIN_UPPER_BOUND    , <TBD> )
-            self.add_spec( SpecName.API_RETUNING_LATENCY   , <TBD> )
-            self.add_spec( SpecName.BANDWIDTH_OPTIONS      , <TBD> )
-    """  
-    def _get_pvalidator_fixed_center_frequency(
-        self
-    ) -> Callable[[Parameters], None]:
-        def pvalidator(parameters: Parameters):
-            validate_fixed_center_frequency(parameters)
-        return pvalidator
+    capture_template = get_base_capture_template( CaptureMode.FIXED_CENTER_FREQUENCY )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
+
+    capture_template.set_defaults(
+        (PName.BATCH_SIZE,            3.0),
+        (PName.CENTER_FREQUENCY,      95800000),
+        (PName.SAMPLE_RATE,           600000),
+        (PName.BANDWIDTH,             600000),
+        (PName.WINDOW_HOP,            512),
+        (PName.WINDOW_SIZE,           1024),
+        (PName.WINDOW_TYPE,           "blackman"),
+        (PName.RF_GAIN,               -30),
+        (PName.IF_GAIN,               -30)
+    )   
+
+    capture_template.add_pconstraint(
+        PName.CENTER_FREQUENCY,
+        [
+            Bound(
+                lower_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
+                upper_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.SAMPLE_RATE,
+        [
+            Bound(
+                lower_bound=sdrplay_receiver.get_spec(SpecName.SAMPLE_RATE_LOWER_BOUND),
+                upper_bound=sdrplay_receiver.get_spec(SpecName.SAMPLE_RATE_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.BANDWIDTH,
+        [
+            OneOf(
+                sdrplay_receiver.get_spec( SpecName.BANDWIDTH_OPTIONS )
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.IF_GAIN,
+        [
+            Bound(
+                upper_bound=sdrplay_receiver.get_spec(SpecName.IF_GAIN_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.RF_GAIN,
+        [
+            Bound(
+                upper_bound=sdrplay_receiver.get_spec(SpecName.RF_GAIN_UPPER_BOUND)
+            )
+        ]
+    )
+    return capture_template
 
 
-    def _get_pvalidator_swept_center_frequency(
-        self
-    ) -> Callable[[Parameters], None]:
-        def pvalidator(parameters: Parameters):
-            validate_swept_center_frequency(parameters,
-                                            self.get_spec(SpecName.API_RETUNING_LATENCY))
-        return pvalidator
+def get_capture_template_swept_center_frequency(
+    sdrplay_receiver: BaseReceiver
+) -> CaptureTemplate:
 
+    capture_template = get_base_capture_template( CaptureMode.SWEPT_CENTER_FREQUENCY )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
 
-    def _get_capture_template_fixed_center_frequency(
-        self
-    ) -> CaptureTemplate:
-        
-        capture_template = get_base_capture_template( CaptureMode.FIXED_CENTER_FREQUENCY )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
+    capture_template.set_defaults(
+        (PName.BATCH_SIZE,            4.0),
+        (PName.MIN_FREQUENCY,         95000000),
+        (PName.MAX_FREQUENCY,         100000000),
+        (PName.SAMPLES_PER_STEP,      80000),
+        (PName.FREQUENCY_STEP,        1536000),
+        (PName.SAMPLE_RATE,           1536000),
+        (PName.BANDWIDTH,             1536000),
+        (PName.WINDOW_HOP,            512),
+        (PName.WINDOW_SIZE,           1024),
+        (PName.WINDOW_TYPE,           "blackman"),
+        (PName.RF_GAIN,               -30),
+        (PName.IF_GAIN,               -30)
+    )   
 
-        capture_template.set_defaults(
-            (PName.BATCH_SIZE,            3.0),
-            (PName.CENTER_FREQUENCY,      95800000),
-            (PName.SAMPLE_RATE,           600000),
-            (PName.BANDWIDTH,             600000),
-            (PName.WINDOW_HOP,            512),
-            (PName.WINDOW_SIZE,           1024),
-            (PName.WINDOW_TYPE,           "blackman"),
-            (PName.RF_GAIN,               -30),
-            (PName.IF_GAIN,               -30)
-        )   
-
-        capture_template.add_pconstraint(
-            PName.CENTER_FREQUENCY,
-            [
-                Bound(
-                    lower_bound=self.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
-                    upper_bound=self.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.SAMPLE_RATE,
-            [
-                Bound(
-                    lower_bound=self.get_spec(SpecName.SAMPLE_RATE_LOWER_BOUND),
-                    upper_bound=self.get_spec(SpecName.SAMPLE_RATE_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.BANDWIDTH,
-            [
-                OneOf(
-                    self.get_spec( SpecName.BANDWIDTH_OPTIONS )
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.IF_GAIN,
-            [
-                Bound(
-                    upper_bound=self.get_spec(SpecName.IF_GAIN_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.RF_GAIN,
-            [
-                Bound(
-                    upper_bound=self.get_spec(SpecName.RF_GAIN_UPPER_BOUND)
-                )
-            ]
-        )
-        return capture_template
-
-
-    def _get_capture_template_swept_center_frequency(
-        self
-    ) -> CaptureTemplate:
-
-        capture_template = get_base_capture_template( CaptureMode.SWEPT_CENTER_FREQUENCY )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
-        capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
-
-        capture_template.set_defaults(
-            (PName.BATCH_SIZE,            4.0),
-            (PName.MIN_FREQUENCY,         95000000),
-            (PName.MAX_FREQUENCY,         100000000),
-            (PName.SAMPLES_PER_STEP,      80000),
-            (PName.FREQUENCY_STEP,        1536000),
-            (PName.SAMPLE_RATE,           1536000),
-            (PName.BANDWIDTH,             1536000),
-            (PName.WINDOW_HOP,            512),
-            (PName.WINDOW_SIZE,           1024),
-            (PName.WINDOW_TYPE,           "blackman"),
-            (PName.RF_GAIN,               -30),
-            (PName.IF_GAIN,               -30)
-        )   
-
-        capture_template.add_pconstraint(
-            PName.MIN_FREQUENCY,
-            [
-                Bound(
-                    lower_bound=self.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
-                    upper_bound=self.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.MAX_FREQUENCY,
-            [
-                Bound(
-                    lower_bound=self.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
-                    upper_bound=self.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.SAMPLE_RATE,
-            [
-                Bound(
-                    lower_bound=self.get_spec(SpecName.SAMPLE_RATE_LOWER_BOUND),
-                    upper_bound=self.get_spec(SpecName.SAMPLE_RATE_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.BANDWIDTH,
-            [
-                OneOf(
-                    self.get_spec( SpecName.BANDWIDTH_OPTIONS )
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.IF_GAIN,
-            [
-                Bound(
-                    upper_bound=self.get_spec(SpecName.IF_GAIN_UPPER_BOUND)
-                )
-            ]
-        )
-        capture_template.add_pconstraint(
-            PName.RF_GAIN,
-            [
-                Bound(
-                    upper_bound=self.get_spec(SpecName.RF_GAIN_UPPER_BOUND)
-                )
-            ]
-        )
-        return capture_template
+    capture_template.add_pconstraint(
+        PName.MIN_FREQUENCY,
+        [
+            Bound(
+                lower_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
+                upper_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.MAX_FREQUENCY,
+        [
+            Bound(
+                lower_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
+                upper_bound=sdrplay_receiver.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.SAMPLE_RATE,
+        [
+            Bound(
+                lower_bound=sdrplay_receiver.get_spec(SpecName.SAMPLE_RATE_LOWER_BOUND),
+                upper_bound=sdrplay_receiver.get_spec(SpecName.SAMPLE_RATE_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.BANDWIDTH,
+        [
+            OneOf(
+                sdrplay_receiver.get_spec( SpecName.BANDWIDTH_OPTIONS )
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.IF_GAIN,
+        [
+            Bound(
+                upper_bound=sdrplay_receiver.get_spec(SpecName.IF_GAIN_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.RF_GAIN,
+        [
+            Bound(
+                upper_bound=sdrplay_receiver.get_spec(SpecName.RF_GAIN_UPPER_BOUND)
+            )
+        ]
+    )
+    return capture_template

--- a/src/spectre_core/receivers/plugins/_usrp.py
+++ b/src/spectre_core/receivers/plugins/_usrp.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2024 Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Callable, overload
+
+from spectre_core.capture_configs import (
+    CaptureTemplate, CaptureMode, Parameters, Bound, PName,
+    get_base_capture_template, get_base_ptemplate, OneOf,
+    validate_fixed_center_frequency, validate_swept_center_frequency
+)
+from .._base import BaseReceiver
+from .._spec_names import SpecName
+
+
+def get_pvalidator_fixed_center_frequency(
+    usrp_receiver: BaseReceiver 
+) -> Callable[[Parameters], None]:
+    def pvalidator(parameters: Parameters) -> None:
+        validate_fixed_center_frequency(parameters)
+    return pvalidator
+
+
+def get_capture_template_fixed_center_frequency(
+    usrp_receiver: BaseReceiver
+) -> CaptureTemplate:
+    
+    capture_template = get_base_capture_template( CaptureMode.FIXED_CENTER_FREQUENCY )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
+
+    capture_template.set_defaults(
+        (PName.BATCH_SIZE,            3.0),
+        (PName.CENTER_FREQUENCY,      95800000),
+        (PName.SAMPLE_RATE,           1000000),
+        (PName.BANDWIDTH,             1000000),
+        (PName.WINDOW_HOP,            512),
+        (PName.WINDOW_SIZE,           1024),
+        (PName.WINDOW_TYPE,           "blackman"),
+        (PName.NORMALISED_GAIN,       0.3),
+    )   
+
+    capture_template.add_pconstraint(
+        PName.CENTER_FREQUENCY,
+        [
+            Bound(
+                lower_bound=usrp_receiver.get_spec(SpecName.FREQUENCY_LOWER_BOUND),
+                upper_bound=usrp_receiver.get_spec(SpecName.FREQUENCY_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.SAMPLE_RATE,
+        [
+            Bound(
+                lower_bound=usrp_receiver.get_spec(SpecName.SAMPLE_RATE_LOWER_BOUND),
+                upper_bound=usrp_receiver.get_spec(SpecName.SAMPLE_RATE_UPPER_BOUND)
+            )
+        ]
+    )
+    capture_template.add_pconstraint(
+        PName.BANDWIDTH,
+        [
+            Bound(
+                lower_bound=usrp_receiver.get_spec( SpecName.BANDWIDTH_LOWER_BOUND ),
+                upper_bound=usrp_receiver.get_spec( SpecName.BANDWIDTH_UPPER_BOUND )
+            )
+        ]
+    )
+    return capture_template

--- a/src/spectre_core/receivers/plugins/_usrp.py
+++ b/src/spectre_core/receivers/plugins/_usrp.py
@@ -27,8 +27,7 @@ def get_capture_template_fixed_center_frequency(
     
     capture_template = get_base_capture_template( CaptureMode.FIXED_CENTER_FREQUENCY )
     capture_template.add_ptemplate( get_base_ptemplate(PName.BANDWIDTH) )
-    capture_template.add_ptemplate( get_base_ptemplate(PName.IF_GAIN) )
-    capture_template.add_ptemplate( get_base_ptemplate(PName.RF_GAIN) )
+    capture_template.add_ptemplate( get_base_ptemplate(PName.NORMALISED_GAIN) )
 
     capture_template.set_defaults(
         (PName.BATCH_SIZE,            3.0),

--- a/src/spectre_core/receivers/plugins/gr/_rsp1a.py
+++ b/src/spectre_core/receivers/plugins/gr/_rsp1a.py
@@ -1,17 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
-#
-# SPDX-License-Identifier: GPL-3.0
-#
-# GNU Radio Python Flow Graph
-# Title: Test receiver
-# GNU Radio version: 3.10.1.1
-
-# SPDX-FileCopyrightText: © 2024 Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>
-# This file is part of SPECTRE
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 #
 # RSP1A receiver top blocks
 #

--- a/src/spectre_core/receivers/plugins/gr/_usrp.py
+++ b/src/spectre_core/receivers/plugins/gr/_usrp.py
@@ -28,9 +28,7 @@ class _fixed_center_frequency(spectre_top_block):
         batch_size       = parameters.get_parameter_value(PName.BATCH_SIZE)
         bandwidth        = parameters.get_parameter_value(PName.BANDWIDTH) 
 
-        ##################################################
         # Blocks
-        ##################################################
         self.uhd_usrp_source_0 = uhd.usrp_source(
             ",".join(("", '')),
             uhd.stream_args(
@@ -46,8 +44,8 @@ class _fixed_center_frequency(spectre_top_block):
         self.uhd_usrp_source_0.set_antenna("RX2", 0)
         self.uhd_usrp_source_0.set_bandwidth(bandwidth, 0)
         self.uhd_usrp_source_0.set_rx_agc(False, 0)
-        self.uhd_usrp_source_0.set_normalised_gain(gain_value, 0)
-        self.spectre_batched_file_sink_0 = spectre.batched_file_sink(batches_dir_path, 
+        self.uhd_usrp_source_0.set_normalised_gain(normalised_gain, 0)
+        self.spectre_batched_file_sink_0 = spectre.batched_file_sink(get_batches_dir_path(), 
                                                                      tag, 
                                                                      batch_size, 
                                                                      sample_rate, False, 
@@ -55,9 +53,7 @@ class _fixed_center_frequency(spectre_top_block):
                                                                      0)
 
 
-        ##################################################
         # Connections
-        ##################################################
         self.connect((self.uhd_usrp_source_0, 0), (self.spectre_batched_file_sink_0, 0))
 
 

--- a/src/spectre_core/receivers/plugins/gr/_usrp.py
+++ b/src/spectre_core/receivers/plugins/gr/_usrp.py
@@ -44,7 +44,7 @@ class _fixed_center_frequency(spectre_top_block):
         self.uhd_usrp_source_0.set_antenna("RX2", 0)
         self.uhd_usrp_source_0.set_bandwidth(bandwidth, 0)
         self.uhd_usrp_source_0.set_rx_agc(False, 0)
-        self.uhd_usrp_source_0.set_normalised_gain(normalised_gain, 0)
+        self.uhd_usrp_source_0.set_normalized_gain(normalised_gain, 0)
         self.spectre_batched_file_sink_0 = spectre.batched_file_sink(get_batches_dir_path(), 
                                                                      tag, 
                                                                      batch_size, 

--- a/src/spectre_core/receivers/plugins/gr/_usrp.py
+++ b/src/spectre_core/receivers/plugins/gr/_usrp.py
@@ -1,0 +1,66 @@
+# 
+# USRP top blocks
+#
+
+from functools import partial
+from dataclasses import dataclass
+import time
+
+from spectre_core.capture_configs import Parameters, PName
+from spectre_core.config import get_batches_dir_path
+from ._base import capture, spectre_top_block
+
+
+class _fixed_center_frequency(spectre_top_block):
+    def flowgraph(
+        self,
+        tag: str,
+        parameters: Parameters
+    ) -> None:
+        # OOT moudle inline imports
+        from gnuradio import spectre
+        from gnuradio import uhd
+
+        # Variables
+        sample_rate      = parameters.get_parameter_value(PName.SAMPLE_RATE)
+        normalised_gain  = parameters.get_parameter_value(PName.NORMALISED_GAIN)
+        center_freq      = parameters.get_parameter_value(PName.CENTER_FREQUENCY)
+        batch_size       = parameters.get_parameter_value(PName.BATCH_SIZE)
+        bandwidth        = parameters.get_parameter_value(PName.BANDWIDTH) 
+
+        ##################################################
+        # Blocks
+        ##################################################
+        self.uhd_usrp_source_0 = uhd.usrp_source(
+            ",".join(("", '')),
+            uhd.stream_args(
+                cpu_format="fc32",
+                args='',
+                channels=list(range(0,1)),
+            ),
+        )
+        self.uhd_usrp_source_0.set_samp_rate(sample_rate)
+        self.uhd_usrp_source_0.set_time_now(uhd.time_spec(time.time()), uhd.ALL_MBOARDS)
+
+        self.uhd_usrp_source_0.set_center_freq(center_freq, 0)
+        self.uhd_usrp_source_0.set_antenna("RX2", 0)
+        self.uhd_usrp_source_0.set_bandwidth(bandwidth, 0)
+        self.uhd_usrp_source_0.set_rx_agc(False, 0)
+        self.uhd_usrp_source_0.set_normalised_gain(gain_value, 0)
+        self.spectre_batched_file_sink_0 = spectre.batched_file_sink(batches_dir_path, 
+                                                                     tag, 
+                                                                     batch_size, 
+                                                                     sample_rate, False, 
+                                                                     'freq', 
+                                                                     0)
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.uhd_usrp_source_0, 0), (self.spectre_batched_file_sink_0, 0))
+
+
+@dataclass(frozen=True)
+class CaptureMethod:
+    fixed_center_frequency = partial(capture, top_block_cls=_fixed_center_frequency)


### PR DESCRIPTION
- feat: Add support for the Ettus Research B200mini receiver for fixed center frequency data capture. Swept center frequency is pending a bug in GNU Radio I have raised as an issue: https://github.com/gnuradio/gnuradio/issues/7725
- feat: Add a template for normalised gain.
- chore: Simplify inheritance hierarchy for sdrplay receivers.