### PR TITLE
feat: Fiddle with values

### DIFF
--- a/src/spectre_core/jobs/_jobs.py
+++ b/src/spectre_core/jobs/_jobs.py
@@ -60,7 +60,7 @@ class Job:
             worker.restart()
 
     def monitor(
-        self, total_runtime: float, force_restart: bool = False, max_restarts: int = 3
+        self, total_runtime: float, force_restart: bool = False, max_restarts: int = 5
     ) -> None:
         """
         Monitor the workers during execution and handle unexpected exits.

--- a/src/spectre_core/jobs/_workers.py
+++ b/src/spectre_core/jobs/_workers.py
@@ -85,7 +85,7 @@ class Worker:
             self.kill()
 
         # a moment of respite
-        time.sleep(Duration.ONE_DECISECOND)
+        time.sleep(0.5 * Duration.ONE_SECOND)
 
         # make a new process, as we can't start the same process again.
         self._process = _make_daemon_process(self._name, self._target)

--- a/src/spectre_core/receivers/plugins/_rsp1a.py
+++ b/src/spectre_core/receivers/plugins/_rsp1a.py
@@ -36,7 +36,7 @@ class RSP1A(BaseReceiver):
         self.add_spec(SpecName.FREQUENCY_UPPER_BOUND, 2e9)
         self.add_spec(SpecName.IF_GAIN_UPPER_BOUND, -20)
         self.add_spec(SpecName.RF_GAIN_UPPER_BOUND, 0)
-        self.add_spec(SpecName.API_RETUNING_LATENCY, 50 * 1e-3)
+        self.add_spec(SpecName.API_RETUNING_LATENCY, 25 * 1e-3)
         self.add_spec(
             SpecName.BANDWIDTH_OPTIONS,
             [200000, 300000, 600000, 1536000, 5000000, 6000000, 7000000, 8000000],


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Increase the default number of times workers can be forcibly restarted during a job.
- Increase the duration of the moment of respite when a worker restarts
- Reduce the assumed API retuning latency for SDRplay receivers from 50ms to 25ms (it still works, just the samples get mixed up. Good for stress testing.)

## Issue link
<!-- Add the link to the related issue(s) -->
n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
