### PR TITLE
Max restart docs

### DIFF
--- a/src/spectre_core/jobs/_jobs.py
+++ b/src/spectre_core/jobs/_jobs.py
@@ -72,7 +72,8 @@ class Job:
 
         :param total_runtime: Total time to monitor the workers, in seconds.
         :param force_restart: Whether to restart all workers if one exits unexpectedly.
-        :param max_restarts: Puts an upper bound on how many times workers can be restarted. If the number of
+        :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+        Only applies when force_restart is True. Defaults to 5.
         :raises RuntimeError: If a worker exits and `force_restart` is False.
         """
         _LOGGER.info("Monitoring workers...")
@@ -118,7 +119,7 @@ class Job:
 
 
 def start_job(
-    workers: list[Worker], total_runtime: float, force_restart: bool = False
+    workers: list[Worker], total_runtime: float, force_restart: bool = False, max_restarts: int = 5
 ) -> None:
     """Create and run a job with the specified workers.
 
@@ -126,9 +127,10 @@ def start_job(
     unexpected exits according to the `force_restart` policy.
 
     :param workers: A list of `Worker` instances to include in the job.
-    :param total_runtime: Total time to monitor the job, in seconds.
+    :param total_runtime: Total time to monitor the workers, in seconds.
     :param force_restart: Whether to restart all workers if one exits unexpectedly.
-    Defaults to False.
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    Only applies when force_restart is True. Defaults to 5.
     """
     job = Job(workers)
     job.start()

--- a/src/spectre_core/jobs/_jobs.py
+++ b/src/spectre_core/jobs/_jobs.py
@@ -134,4 +134,4 @@ def start_job(
     """
     job = Job(workers)
     job.start()
-    job.monitor(total_runtime, force_restart)
+    job.monitor(total_runtime, force_restart, max_restarts)

--- a/src/spectre_core/jobs/_jobs.py
+++ b/src/spectre_core/jobs/_jobs.py
@@ -71,7 +71,7 @@ class Job:
         - Kills all workers and raises an exception if `force_restart` is False.
 
         :param total_runtime: Total time to monitor the workers, in seconds.
-        :param force_restart: Whether to restart all workers if one exits unexpectedly.
+        :param force_restart: Whether to restart all workers if one dies unexpectedly.
         :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
         Only applies when force_restart is True. Defaults to 5.
         :raises RuntimeError: If a worker exits and `force_restart` is False.
@@ -128,7 +128,7 @@ def start_job(
 
     :param workers: A list of `Worker` instances to include in the job.
     :param total_runtime: Total time to monitor the workers, in seconds.
-    :param force_restart: Whether to restart all workers if one exits unexpectedly.
+    :param force_restart: Whether to restart all workers if one dies unexpectedly.
     :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
     Only applies when force_restart is True. Defaults to 5.
     """

--- a/src/spectre_core/jobs/_jobs.py
+++ b/src/spectre_core/jobs/_jobs.py
@@ -72,7 +72,7 @@ class Job:
 
         :param total_runtime: Total time to monitor the workers, in seconds.
         :param force_restart: Whether to restart all workers if one dies unexpectedly.
-        :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+        :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers.
         Only applies when force_restart is True. Defaults to 5.
         :raises RuntimeError: If a worker exits and `force_restart` is False.
         """
@@ -119,7 +119,10 @@ class Job:
 
 
 def start_job(
-    workers: list[Worker], total_runtime: float, force_restart: bool = False, max_restarts: int = 5
+    workers: list[Worker],
+    total_runtime: float,
+    force_restart: bool = False,
+    max_restarts: int = 5,
 ) -> None:
     """Create and run a job with the specified workers.
 
@@ -129,7 +132,7 @@ def start_job(
     :param workers: A list of `Worker` instances to include in the job.
     :param total_runtime: Total time to monitor the workers, in seconds.
     :param force_restart: Whether to restart all workers if one dies unexpectedly.
-    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers.
     Only applies when force_restart is True. Defaults to 5.
     """
     job = Job(workers)


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Formatting, docstrings, and non-breakingly adds the `max_restarts` argument to the `start_job` function.

## Issue link
<!-- Add the link to the related issue(s) -->
-

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
