### PR TITLE
hotfix: b200mini flowgraph typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-core"
-version = "0.0.26"
+version = "0.0.27"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/src/spectre_core/__init__.py
+++ b/src/spectre_core/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"

--- a/src/spectre_core/receivers/plugins/_b200mini.py
+++ b/src/spectre_core/receivers/plugins/_b200mini.py
@@ -60,7 +60,6 @@ def _make_capture_template_fixed_center_frequency(
     capture_template.add_ptemplate(get_base_ptemplate(PName.WIRE_FORMAT))
     capture_template.add_ptemplate(get_base_ptemplate(PName.MASTER_CLOCK_RATE))
 
-    # TODO: Delegate defaults to receiver subclasses. Currently, these are sensible defaults for the b200mini
     capture_template.set_defaults(
         (PName.BATCH_SIZE, 4.0),
         (PName.CENTER_FREQUENCY, 95800000),

--- a/src/spectre_core/receivers/plugins/_b200mini_gr.py
+++ b/src/spectre_core/receivers/plugins/_b200mini_gr.py
@@ -26,7 +26,7 @@ class fixed_center_frequency(spectre_top_block):
 
         # Blocks
         master_clock_rate = f"master_clock_rate={master_clock_rate}"
-        self.uhd_usrp_sourcespecs.get = uhd.usrp_source(
+        self.uhd_usrp_source = uhd.usrp_source(
             ",".join(("", "", master_clock_rate)),
             uhd.stream_args(
                 cpu_format="fc32",


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Fixes a ctrl f search and replace all error, which resulted in an error trying to run the flowgraph for the `b200mini` receiver, operating in the mode `fixed_center_frequency`.

## Issue link
<!-- Add the link to the related issue(s) -->
n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
