### PR TITLE
fix: Correctly compute the number of spectrums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-core"
-version = "1.1.1"
+version = "1.1.2"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/src/spectre_core/__init__.py
+++ b/src/spectre_core/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.0.0"
+__version__ = "1.1.2"

--- a/src/spectre_core/post_processing/_stfft.py
+++ b/src/spectre_core/post_processing/_stfft.py
@@ -139,7 +139,22 @@ def get_num_spectrums(signal_size: int, window_size: int, window_hop: int) -> in
     :return: The total number of spectrums in the resulting spectrogram, when performing an
     stfft with these values.
     """
-    return int(np.ceil((signal_size - (window_size // 2 - 1)) / window_hop))
+    if window_size < 1:
+        raise ValueError(
+            f"The window size must be at least one. " f"Got {window_size}."
+        )
+
+    if window_hop < 1:
+        raise ValueError(f"The window hop must be at least one. " f"Got {window_hop}.")
+
+    if window_size > signal_size:
+        raise ValueError(
+            f"The window must fit within the signal. "
+            f"Got window size {window_size}, which is greater "
+            f"than the signal size {signal_size}."
+        )
+
+    return int((signal_size - np.ceil(window_size / 2)) / window_hop) + 1
 
 
 def stfft(

--- a/src/spectre_core/post_processing/_stfft.py
+++ b/src/spectre_core/post_processing/_stfft.py
@@ -138,6 +138,7 @@ def get_num_spectrums(signal_size: int, window_size: int, window_hop: int) -> in
     :param window_hop: The number of samples the window is shifted in each frame.
     :return: The total number of spectrums in the resulting spectrogram, when performing an
     stfft with these values.
+    :raises ValueError: If the window size or hop is less than one sample, or the window size is greater than the signal size.
     """
     if window_size < 1:
         raise ValueError(

--- a/tests/unit/test_post_processing.py
+++ b/tests/unit/test_post_processing.py
@@ -96,7 +96,67 @@ class TestSTFFT:
 
     @pytest.mark.parametrize(
         ("signal_size", "window_size", "window_hop", "expected_num_spectrums"),
-        [(16, 8, 8, 2), (16, 8, 4, 4), (16, 7, 2, 7)],
+        [
+            # Even signal size, even window size, even hop. Window size less than the hop.
+            (8, 4, 2, 4),
+            # Even signal size, even window size, even hop. Window size equal to the hop.
+            (8, 4, 4, 2),
+            # Even signal size, even window size, even hop. Window size greater than the hop.
+            (8, 4, 6, 2),
+            # Even signal size, even window size, odd hop. Window size less than the hop.
+            (8, 4, 3, 3),
+            # Even signal size, even window size, odd hop. Window size more than the hop.
+            (8, 4, 5, 2),
+            # Even signal size, odd window size, even hop. Window size less than the hop.
+            (8, 3, 2, 4),
+            # Even signal size, odd window size, even hop. Window size greater than the hop.
+            (8, 3, 4, 2),
+            # Even signal size, odd window size, odd hop. Window size less than the hop.
+            (8, 5, 3, 2),
+            # Even signal size, odd window size, odd hop. Window size equal to the hop.
+            (8, 5, 5, 2),
+            # Even signal size, odd window size, odd hop. Window size greater than the hop.
+            (8, 3, 5, 2),
+            # Odd signal size, even window size, even hop. Window size less than the hop.
+            (9, 4, 2, 4),
+            # Odd signal size, even window size, even hop. Window size equal to the hop.
+            (9, 4, 4, 2),
+            # Odd signal size, even window size, even hop. Window size greater than the hop.
+            (9, 4, 6, 2),
+            # Odd signal size, even window size, odd hop. Window size less than the hop.
+            (9, 4, 3, 3),
+            # Odd signal size, even window size, odd hop. Window size more than the hop.
+            (9, 4, 5, 2),
+            # Odd signal size, odd window size, even hop. Window size less than the hop.
+            (9, 3, 2, 4),
+            # Odd signal size, odd window size, even hop. Window size greater than the hop.
+            (9, 3, 4, 2),
+            # Odd signal size, odd window size, odd hop. Window size less than the hop.
+            (9, 5, 3, 3),
+            # Odd signal size, odd window size, odd hop. Window size equal to the hop.
+            (9, 5, 5, 2),
+            # Odd signal size, odd window size, odd hop. Window size greater than the hop.
+            (9, 3, 5, 2),
+            # Minimum window size.
+            (8, 1, 4, 2),
+            # Minimum hop size.
+            (8, 3, 1, 7),
+            # Minimum window size and minimum hop size.
+            (8, 1, 1, 8),
+            # Even signal size, maximum window size and hop.
+            (8, 8, 4, 2),
+            # Odd signal size, maximum window size and hop.
+            (9, 9, 4, 2),
+            # Window hop is greater than the signal size.
+            (9, 9, 10, 1),
+            # Window hop is much greater than the signal size.
+            (9, 9, 999, 1),
+            # Old test cases to make sure the new implementation is compatible with v1.1.1
+            # At least, according to those test cases.
+            (16, 8, 8, 2),
+            (16, 8, 4, 4),
+            (16, 7, 2, 7),
+        ],
     )
     def test_num_spectrums(
         self,
@@ -109,6 +169,27 @@ class TestSTFFT:
         assert expected_num_spectrums == get_num_spectrums(
             signal_size, window_size, window_hop
         )
+
+    @pytest.mark.parametrize(
+        ("signal_size", "window_size", "window_hop"),
+        [
+            # The window size cannot be less than one.
+            (8, 0, 4),
+            # The window hop cannot be less than one.
+            (8, 4, 0),
+            # The window must fit within the signal.
+            (8, 9, 4),
+        ],
+    )
+    def test_invalid_num_spectrums(
+        self,
+        signal_size: int,
+        window_size: int,
+        window_hop: int,
+    ) -> None:
+        """Check that passing bad arguments yields a ValueError in various cases."""
+        with pytest.raises(ValueError):
+            get_num_spectrums(signal_size, window_size, window_hop)
 
     def test_stfft(self) -> None:
         """Check that the stfft of a simple cosine wave matches the analytically derived solution."""


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Corrects the formula used to compute the number of spectrums in each spectrogram output by the short-time discrete Fourier transform. I've also provided more robust testing, checking the function output against hand-worked-out examples.

## Issue link
<!-- Add the link to the related issue(s) -->
> n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
