### PR TITLE
Add missing `wire_format`/`output_type` validation to swept frequency modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-core"
-version = "3.1.0"
+version = "3.1.1"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/src/spectre_core/__init__.py
+++ b/src/spectre_core/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/src/spectre_core/models/_b200mini.py
+++ b/src/spectre_core/models/_b200mini.py
@@ -137,4 +137,6 @@ class B200miniSweptCenterFrequency(
         validate_sample_rate_with_master_clock_rate(
             self.sample_rate, self.master_clock_rate
         )
+        validate_wire_format(self.wire_format)
+        validate_output_type(self.output_type)
         return self

--- a/src/spectre_core/models/_usrp.py
+++ b/src/spectre_core/models/_usrp.py
@@ -60,4 +60,6 @@ class USRPSweptCenterFrequency(
         validate_sample_rate_with_master_clock_rate(
             self.sample_rate, self.master_clock_rate
         )
+        validate_wire_format(self.wire_format)
+        validate_output_type(self.output_type)
         return self

--- a/tests/unit/test_receivers.py
+++ b/tests/unit/test_receivers.py
@@ -237,7 +237,7 @@ class TestReceivers:
     def test_invalid_single_field_all_modes(
         self, receiver_name: str, field_name: str, field_values: list[typing.Any]
     ) -> None:
-        """Check a receiver rejects a valid single field, for all modes."""
+        """Check a receiver rejects an invalid single field, for all modes."""
         receiver = spectre_core.receivers.get_receiver(receiver_name)
         for mode in receiver.modes:
             receiver.mode = mode

--- a/tests/unit/test_receivers.py
+++ b/tests/unit/test_receivers.py
@@ -2,14 +2,18 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import pytest
+import typing
 import os
+
+import pytest
+import pydantic
 
 import spectre_core.receivers
 import spectre_core.exceptions
 import spectre_core.config
 
 ACTIVE_MODE = "cosine_wave"
+INVALID_STRING_FIELD = "foobarbaz"
 
 
 @pytest.fixture
@@ -173,3 +177,70 @@ class TestReceivers:
                     tag, spectre_config_paths.get_configs_dir_path()
                 )
             )
+
+    @pytest.mark.parametrize(
+        ("receiver_name", "field_name", "field_values"),
+        [
+            (
+                spectre_core.receivers.ReceiverName.B200MINI,
+                "wire_format",
+                ["sc8", "sc12", "sc16"],
+            ),
+            (
+                spectre_core.receivers.ReceiverName.B200MINI,
+                "output_type",
+                ["fc32", "sc16"],
+            ),
+            (
+                spectre_core.receivers.ReceiverName.USRP,
+                "wire_format",
+                ["sc8", "sc12", "sc16"],
+            ),
+            (spectre_core.receivers.ReceiverName.USRP, "output_type", ["fc32", "sc16"]),
+        ],
+    )
+    def test_valid_single_field_all_modes(
+        self, receiver_name: str, field_name: str, field_values: list[typing.Any]
+    ) -> None:
+        """Check a receiver accepts a valid single field, for all modes."""
+        receiver = spectre_core.receivers.get_receiver(receiver_name)
+        for mode in receiver.modes:
+            receiver.mode = mode
+            for field_value in field_values:
+                receiver.model_validate({field_name: field_value})
+
+    @pytest.mark.parametrize(
+        ("receiver_name", "field_name", "field_values"),
+        [
+            (
+                spectre_core.receivers.ReceiverName.B200MINI,
+                "wire_format",
+                [INVALID_STRING_FIELD],
+            ),
+            (
+                spectre_core.receivers.ReceiverName.B200MINI,
+                "output_type",
+                [INVALID_STRING_FIELD],
+            ),
+            (
+                spectre_core.receivers.ReceiverName.USRP,
+                "wire_format",
+                [INVALID_STRING_FIELD],
+            ),
+            (
+                spectre_core.receivers.ReceiverName.USRP,
+                "output_type",
+                [INVALID_STRING_FIELD],
+            ),
+        ],
+    )
+    def test_invalid_single_field_all_modes(
+        self, receiver_name: str, field_name: str, field_values: list[typing.Any]
+    ) -> None:
+        """Check a receiver rejects a valid single field, for all modes."""
+        receiver = spectre_core.receivers.get_receiver(receiver_name)
+        for mode in receiver.modes:
+            receiver.mode = mode
+            for field_value in field_values:
+                with pytest.raises(pydantic.ValidationError):
+                    receiver.model_validate({field_name: field_value})


### PR DESCRIPTION
## What does this PR do?

In both `B200miniSweptCenterFrequency` and `USRPSweptCenterFrequency`, calls to `validate_wire_format` and `validate_output_type` were missing from the `validator' method, despite being present in their respective `fixed_center_frequency` counterparts. This allowed invalid values to pass through without error in `swept_center_frequency` mode.

## Issue link

(Resolves jcfitzpatrick12/spectre#197.)

## Checklist before merging

- [x] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [x] I have formatted Python code with `black`
- [x] I have checked static type hinting with `mypy`
- [x] I have added/updated necessary documentation, if required
- [x] I have checked for and resolved any merge conflicts
- [x] I have performed a self-review of my code

## Additional notes

As with my most recent PR, `mypy` issues were found unrelated to this diff.

Additionally, @jcfitzpatrick12, I'm not sure if you want to edit any unit tests directly related to this topic? I do suspect it would be a good idea, but in the meantime, what I've done is test the script
```bash
#!/bin/bash

podman exec spectre-cli spectre create config -t mre1 -r b200mini -m swept_center_frequency -p wire_format=whyMustThereBeASnowstormToday
podman exec spectre-cli spectre create config -t mre2 -r usrp -m swept_center_frequency -p wire_format=1011bears
podman exec spectre-cli spectre create config -t mre3 -r b200mini -m swept_center_frequency -p output_type=strawberryShortcakeSailors
podman exec spectre-cli spectre create config -t mre4 -r usrp -m swept_center_frequency -p output_type=meowSqueak
```
in a local `podman`/`docker` container. Before the bugfix, all four commands ran without issue, but I've since confirmed that they all now throw errors as expected:
```
An internal server error has occured. Received the following error: 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/_format_responses.py", line 96, in wrapper
    data = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/configs.py", line 70, in create_config
    config_file_path = services.create_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/logs/_decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/services/configs.py", line 140, in create_config
    receiver.write_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 235, in write_config
    self.model_validate(parameters, skip=skip_validation).model_dump(),
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 190, in model_validate
    return self.model_cls.model_validate(parameters, context={"skip": skip})
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for B200miniSweptCenterFrequency
  Value error, wire_format must be one of ['sc8', 'sc12', 'sc16']. Got whyMustThereBeASnowstormToday. [type=value_error, input_value={'wire_format': 'whyMustThereBeASnowstormToday'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
Use `spectre get log` for more information.
An internal server error has occured. Received the following error: 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/_format_responses.py", line 96, in wrapper
    data = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/configs.py", line 70, in create_config
    config_file_path = services.create_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/logs/_decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/services/configs.py", line 140, in create_config
    receiver.write_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 235, in write_config
    self.model_validate(parameters, skip=skip_validation).model_dump(),
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 190, in model_validate
    return self.model_cls.model_validate(parameters, context={"skip": skip})
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for USRPSweptCenterFrequency
  Value error, wire_format must be one of ['sc8', 'sc12', 'sc16']. Got 1011bears. [type=value_error, input_value={'wire_format': '1011bears'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
Use `spectre get log` for more information.
An internal server error has occured. Received the following error: 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/_format_responses.py", line 96, in wrapper
    data = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/configs.py", line 70, in create_config
    config_file_path = services.create_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/logs/_decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/services/configs.py", line 140, in create_config
    receiver.write_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 235, in write_config
    self.model_validate(parameters, skip=skip_validation).model_dump(),
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 190, in model_validate
    return self.model_cls.model_validate(parameters, context={"skip": skip})
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for B200miniSweptCenterFrequency
  Value error, output_type must be one of ['fc32', 'sc16']. Got strawberryShortcakeSailors. [type=value_error, input_value={'output_type': 'strawberryShortcakeSailors'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
Use `spectre get log` for more information.
An internal server error has occured. Received the following error: 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/_format_responses.py", line 96, in wrapper
    data = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/routes/configs.py", line 70, in create_config
    config_file_path = services.create_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/logs/_decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/spectre_server/services/configs.py", line 140, in create_config
    receiver.write_config(
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 235, in write_config
    self.model_validate(parameters, skip=skip_validation).model_dump(),
  File "/usr/local/lib/python3.10/dist-packages/spectre_core/receivers/_base.py", line 190, in model_validate
    return self.model_cls.model_validate(parameters, context={"skip": skip})
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for USRPSweptCenterFrequency
  Value error, output_type must be one of ['fc32', 'sc16']. Got meowSqueak. [type=value_error, input_value={'output_type': 'meowSqueak'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
Use `spectre get log` for more information.
```
(I also think it's worth noting that "occured" is misspelled - fortunate catch so we can fix the error message in the future, I suppose.) Let me know if you'd like to actually add unit tests, or just merge this for now.